### PR TITLE
Fix: secrets for db

### DIFF
--- a/script/seed.js
+++ b/script/seed.js
@@ -1,5 +1,7 @@
 "use strict";
 
+if (process.env.NODE_ENV !== "production") require("../secrets");
+
 const db = require("../server/db");
 const {User, Post, Comment} = require("../server/db/models");
 const {admins, posts, users, comments} = require("./seedData");

--- a/server/index.js
+++ b/server/index.js
@@ -5,6 +5,7 @@ const compression = require("compression");
 const session = require("express-session");
 const passport = require("passport");
 const SequelizeStore = require("connect-session-sequelize")(session.Store);
+if (process.env.NODE_ENV !== "production") require("../secrets");
 const db = require("./db");
 const sessionStore = new SequelizeStore({
 	db
@@ -17,8 +18,6 @@ module.exports = app;
 if (process.env.NODE_ENV === "test") {
 	after("close the session store", () => sessionStore.stopExpiringSessions());
 }
-
-if (process.env.NODE_ENV !== "production") require("../secrets");
 
 passport.serializeUser((user, done) => done(null, user.id));
 


### PR DESCRIPTION
Previously we were loading in the secrets.js after we load in the db
module.  This means all the code in db.js has no chance to use the
secrets and it just goes to the defaults.  Now secrets will be loaded
before we run the db code.