### PR TITLE
Feat: tags shown on all posts, seed with post tags

### DIFF
--- a/client/components/AllPosts.js
+++ b/client/components/AllPosts.js
@@ -1,7 +1,7 @@
 import React from "react";
 import {connect} from "react-redux";
 import {Link} from "react-router-dom";
-import {Col, Row} from "reactstrap";
+import {Col, Row, Badge} from "reactstrap";
 import {fetchPosts, deletePostThunk} from "../store/post";
 import LikePost from "./LikePost";
 import updatePost from "./updatePost";
@@ -70,6 +70,13 @@ class AllPosts extends React.Component {
 								) : (
 									""
 								)}
+							</Row>
+							<Row>
+								{post.tags.map(tag => (
+									<Badge variant="primary" key={tag.id}>
+										{tag.text}
+									</Badge>
+								))}
 							</Row>
 						</div>
 					))}

--- a/script/seed.js
+++ b/script/seed.js
@@ -13,14 +13,6 @@ async function seed() {
 		});
 		console.log("db synced!");
 
-		const allPosts = [...posts];
-
-		await Promise.all(
-			allPosts.map(post => {
-				return Post.create(post);
-			})
-		);
-
 		const allUsers = [...admins, ...users];
 
 		await Promise.all(
@@ -34,6 +26,20 @@ async function seed() {
 		await Promise.all(
 			allTags.map(tag => {
 				return Tag.create(tag);
+			})
+		);
+
+		const allPosts = [...posts];
+
+		const createdPosts = await Promise.all(
+			allPosts.map(post => {
+				return Post.create(post);
+			})
+		);
+
+		await Promise.all(
+			createdPosts.map((post, i) => {
+				return post.addTags(postTags[i]);
 			})
 		);
 

--- a/script/seedData.js
+++ b/script/seedData.js
@@ -53,6 +53,11 @@ const posts = [
 	}
 ];
 
+// 0th post from above will get the 0th set of tags from this array
+// and so on.  These are lined up with the id of the tags which comes
+// from the order of the tags array
+const postTags = [[1, 4], [1, 4], [1, 4], [1, 4], [1, 4]];
+
 const tags = [
 	{
 		text: "1990",
@@ -122,5 +127,6 @@ module.exports = {
 	posts,
 	admins,
 	users,
-	tags
+	tags,
+	postTags
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,7 +3,7 @@ const dotenv = require("dotenv");
 
 const isDev = process.env.NODE_ENV === "development";
 
-const env = dotenv.config().parsed;
+const env = dotenv.config().parsed || {};
 
 // reduce it to a nice object
 const envKeys = Object.keys(env).reduce((prev, next) => {


### PR DESCRIPTION
Added a post tags part of the seeding process to make testing easier.
Gets the created posts from before and just calls the `addTags` method
on them for the set of tags we want that post to have.

Also create a bootstrap `Badge` per tag per post on the all posts page.

![all post tags](https://user-images.githubusercontent.com/5507187/93733105-0bd4f180-fba2-11ea-9cb3-f0bf94f47a25.PNG)

Needs some style, but functional
