### PR TITLE
Fix: update post picture path in route

### DIFF
--- a/client/components/newPostForm.js
+++ b/client/components/newPostForm.js
@@ -197,15 +197,9 @@ class NewPostForm extends Component {
 					/>
 				</div>
 
-				{this.isUpdate() ? (
-					<Button variant="outline-primary" size="lg" type="submit">
-						Update
-					</Button>
-				) : (
-					<Button variant="outline-primary" size="lg" type="submit">
-						Create
-					</Button>
-				)}
+				<Button variant="outline-primary" size="lg" type="submit">
+					{this.isUpdate() ? "Update" : "Create"}
+				</Button>
 			</Form>
 		);
 	}

--- a/server/api/posts.js
+++ b/server/api/posts.js
@@ -56,7 +56,6 @@ router.get("/:postId", async (req, res, next) => {
 
 router.post("/:id", upload.single("image"), async (req, res, next) => {
 	try {
-		const path = req.file && req.file.path;
 		const {
 			title,
 			description,
@@ -65,27 +64,20 @@ router.post("/:id", upload.single("image"), async (req, res, next) => {
 			credits,
 			pictureDescription
 		} = req.body;
-		let params = {};
-		if (path) {
-			params = {
-				title,
-				description,
-				date,
-				imageTitle,
-				credits,
-				pictureDescription,
-				imageName: path
-			};
-		} else {
-			params = {
-				title,
-				description,
-				date,
-				credits,
-				pictureDescription,
-				imageTitle
-			};
+
+		let params = {
+			title,
+			description,
+			date,
+			imageTitle,
+			credits,
+			pictureDescription
+		};
+
+		if (req.file && req.file.path) {
+			params.imageName = req.file.path.slice(8);
 		}
+
 		const post = await Post.update(params, {
 			where: {
 				id: req.params.id


### PR DESCRIPTION
It was 404 before because the route was saving the new image with the
'upload/' prefix.  Our images in uploads are served from the base
slash, for example "/new_image.jpg" instead of
"/uploads/new_image.jpg".